### PR TITLE
Add imports table to bytecode format

### DIFF
--- a/src/api/parser_constants.rs
+++ b/src/api/parser_constants.rs
@@ -7,7 +7,7 @@ This module describes constant values used in bytecode reading and writing.
 pub(crate) const MAGIC_NUMBER: u32 = 0x52564D88;
 
 /// Format version number
-pub(crate) const VERSION: u16 = 2;
+pub(crate) const VERSION: u16 = 3;
 
 /*
  * Constant types

--- a/src/objects/codeholder.rs
+++ b/src/objects/codeholder.rs
@@ -8,6 +8,8 @@ pub struct CodeHolder {
     pub instructions: Vec<Instruction>,
     /// A pool of immutable data that is available to the VM at runtime.
     pub constant_pool: Vec<Constant>,
+    /// A list of imports that are required to properly link with the application
+    pub(crate) imports: Vec<String>,
 }
 
 impl CodeHolder {
@@ -16,6 +18,7 @@ impl CodeHolder {
         CodeHolder {
             instructions: Vec::new(),
             constant_pool: Vec::new(),
+            imports: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
This pull request adds the planned imports table into the bytecode reader and writer code as part of issue #5. I am unable to fully test this change right now, but everything should work.